### PR TITLE
build: switch backend from uv_build to hatchling to fix brew install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@ requires-python = ">=3.12"
 dependencies = []
 
 [build-system]
-requires = ["uv_build>=0.9.26,<0.10.0"]
-build-backend = "uv_build"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [project.scripts]
 git-pulsar = "src.cli:main"


### PR DESCRIPTION
## 🛠️ Build System Migration

### 📝 Summary
Switches the build backend in `pyproject.toml` from `uv_build` to `hatchling`.

### 💥 Problem
Users installing via Homebrew were encountering build failures with Python 3.14 (and 3.13 in isolated environments).
* **Root Cause:** `uv_build` and its dependency `maturin` are Rust-based. When pre-built wheels are unavailable (or forbidden by Homebrew's `--no-binary` policy), `pip` attempts to compile them from source.
* **Failure:** The Homebrew sandbox does not have a Rust compiler (`cargo`), causing the install to error out.
* **Performance:** Even if we added Rust, compiling the build backend adds ~5 minutes to the installation time.

### ✅ Solution
Migrate to `hatchling`, a modern, pure-Python build backend.
* **Compatibility:** Works seamlessly with `uv` for local development.
* **Speed:** Homebrew can "build" the package in seconds without external system dependencies.
* **Stability:** Removes the need to pin Python versions or manage Rust toolchains in the tap formula.