### PR TITLE
feat: add argcomplete for shell autocompletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,22 @@ uv tool install git-pulsar
 git pulsar install-service --interval 300
 ```
 
+### Shell Completion
+
+Git Pulsar supports tab completion for Bash, Zsh, and Tcsh via `argcomplete`.
+To enable it globally, run:
+
+```bash
+uv tool install argcomplete
+register-python-argcomplete git-pulsar >> ~/.bashrc  # Or ~/.zshrc
+```
+
+Alternatively, you can evaluate it dynamically in your shell session:
+
+```bash
+eval "$(register-python-argcomplete git-pulsar)"
+```
+
 ---
 
 ## 🚀 The Pulsar Workflow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = [
 ]
 requires-python = ">=3.12"
 dependencies = [
+    "argcomplete>=3.5.0",
     "rich>=14.2.0",
 ]
 license = {file = "LICENSE"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "argcomplete>=3.5.0",
+    "argcomplete>=3.7.2",
     "rich>=14.2.0",
 ]
 license = {file = "LICENSE"}

--- a/src/git_pulsar/cli.py
+++ b/src/git_pulsar/cli.py
@@ -9,6 +9,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
+import argcomplete
 from rich.console import Console
 from rich.panel import Panel
 from rich.prompt import Confirm
@@ -1187,6 +1188,7 @@ def main() -> None:
         "--days", type=int, default=30, help="Age in days (default: 30)"
     )
 
+    argcomplete.autocomplete(parser)
     args = parser.parse_args()
 
     # Handle Subcommands

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "argcomplete"
+version = "3.7.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/87/6f/5a73f04007ca950701765949209f068da628bd11f9c2da287278ce91e0ee/argcomplete-3.7.2.tar.gz", hash = "sha256:aad8b69a0b9969edb62db0d1752354c0d50717b10e0cbb00e2a958381b9fc6b9", size = 74473, upload-time = "2026-08-06T04:53:21.662Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/bd/551ee6af426af84ca33e02622be722925c196608e9127d731ef17c47f06e/argcomplete-3.7.2-py3-none-any.whl", hash = "sha256:6029205678bdd9c1c728a155f5f9ecf5812393f969eef58807641a2bc2aa5b19", size = 43294, upload-time = "2026-08-06T04:53:20.246Z" },
+]
+
+[[package]]
 name = "ast-serialize"
 version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -144,6 +153,7 @@ name = "git-pulsar"
 version = "0.16.0"
 source = { editable = "." }
 dependencies = [
+    { name = "argcomplete" },
     { name = "rich" },
 ]
 
@@ -159,7 +169,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "rich", specifier = ">=14.2.0" }]
+requires-dist = [
+    { name = "argcomplete", specifier = ">=3.5.0" },
+    { name = "rich", specifier = ">=14.2.0" },
+]
 
 [package.metadata.requires-dev]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -170,7 +170,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "argcomplete", specifier = ">=3.5.0" },
+    { name = "argcomplete", specifier = ">=3.7.2" },
     { name = "rich", specifier = ">=14.2.0" },
 ]
 


### PR DESCRIPTION
## Description

This PR introduces shell tab-completion for `git-pulsar` using the `argcomplete` library.

Given the significant number of subcommands (`status`, `sync`, `restore`, `doctor`, `pause`, `resume`, `prune`, `config`, etc.), tab-completion makes the CLI significantly more discoverable and user-friendly.

### Changes Made
- Added `argcomplete>=3.5.0` to `pyproject.toml` dependencies.
- Integrated `argcomplete.autocomplete(parser)` into `src/git_pulsar/cli.py` right before `parser.parse_args()`.
- Updated `README.md` with instructions on how users can globally or dynamically enable shell completions.

### Testing
- Validated via `just lint` and `just typecheck`.
