### PR TITLE
feat: make multi-machine synchronization opt-in by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ In a distributed environment (Laptop ↔ Desktop), state drift is inevitable.
 
 - **Decoupled Cycles:** Independent intervals for local commits and remote pushes. Save your battery while staying protected.
 - **Smart Identity:** Automatically detects naming collisions with other devices on the remote, ensuring unique backup streams for every machine.
-- **Roaming Radar:** The background daemon actively polls for topological drift, firing a cross-platform OS notification if another machine leapfrogs your local session so you can `sync` before conflicts arise.
+- **Roaming Radar:** *(Requires `sync_enabled = true`)* The background daemon actively polls for topological drift, firing a cross-platform OS notification if another machine leapfrogs your local session so you can `sync` before conflicts arise.
 - **Out-of-Band Indexing:** Backups are stored in a configured namespace (default: `refs/heads/wip/pulsar/...`). Your `git status`, `git branch`, and `git log` remain completely clean.
-- **Distributed Sessions:** Hop between machines. Pulsar tracks sessions per device and lets you `sync` to pick up exactly where you left off.
+- **Distributed Sessions:** *(Requires `sync_enabled = true`)* Hop between machines. Pulsar tracks sessions per device and lets you `sync` to pick up exactly where you left off.
 - **State-Aware Diagnostics:** The `doctor` command correlates transient log events with active system health to prevent alert fatigue, proactively scans for pipeline blockers, and offers an interactive queue to safely auto-fix common issues.
 - **Active Observability:** The `status` dashboard provides zero-latency power telemetry (e.g., Eco-Mode throttling) and immediately surfaces cached warnings for remote session drift and oversized files.
 - **Zero-Interference:**
@@ -255,6 +255,7 @@ A comprehensive, self-documenting global configuration file (`~/.config/git-puls
 | `daemon` | `preset` | `None` | Use `paranoid`, `aggressive`, `balanced`, or `lazy`. |
 | `daemon` | `commit_interval` | `600` | Seconds between local state captures. |
 | `daemon` | `push_interval` | `3600` | Seconds between remote pushes. |
+| `daemon` | `sync_enabled` | `false` | Enable to sync backups across machines. |
 | `limits` | `large_file_threshold` | `100MB` | Max file size before aborting a backup. |
 
 ### Example `~/.config/git-pulsar/config.toml`
@@ -264,11 +265,12 @@ A comprehensive, self-documenting global configuration file (`~/.config/git-puls
 # Uncomment settings below to override their defaults.
 
 [daemon]
-# preset = "balanced"
-# eco_mode_percent = 20
+preset = "balanced"
+sync_enabled = true      # Set to true to push backups and sync across machines
+eco_mode_percent = 25  # Throttles pushes if battery is low
 
 [files]
-# ignore = ["*.tmp", "node_modules/"]
+ignore = ["*.tmp", "node_modules/"]
 ```
 
 ---

--- a/scripts/test_distributed.sh
+++ b/scripts/test_distributed.sh
@@ -72,6 +72,8 @@ cd "$MAC1_DIR"
 export HOME="$TEST_DIR/home_mac1"
 export XDG_STATE_HOME="$TEST_DIR/state_mac1"
 mkdir -p "$HOME"
+mkdir -p "$HOME/.config/git-pulsar"
+echo -e "[daemon]\nsync_enabled = true" > "$HOME/.config/git-pulsar/config.toml"
 
 # 1. Make the initial commit and push FIRST
 echo "print('hello distributed world')" > main.py
@@ -95,6 +97,8 @@ cd "$MAC2_DIR"
 export HOME="$TEST_DIR/home_mac2"
 export XDG_STATE_HOME="$TEST_DIR/state_mac2"
 mkdir -p "$HOME"
+mkdir -p "$HOME/.config/git-pulsar"
+echo -e "[daemon]\nsync_enabled = true" > "$HOME/.config/git-pulsar/config.toml"
 
 # Initialize registry with a unique machine name
 echo "node-b" | "$PULSAR_BIN" > /dev/null

--- a/src/git_pulsar/config.py
+++ b/src/git_pulsar/config.py
@@ -103,6 +103,7 @@ class DaemonConfig:
     min_battery_percent: int = 10
     eco_mode_percent: int = 20
     preset: str | None = None
+    sync_enabled: bool = False
 
     def apply_preset(self) -> None:
         """Overwrites intervals based on the selected preset."""

--- a/src/git_pulsar/daemon.py
+++ b/src/git_pulsar/daemon.py
@@ -356,7 +356,7 @@ def run_backup(original_path_str: str, interactive: bool = False) -> None:
             return
 
         # --- ROAMING RADAR (DRIFT DETECTION) ---
-        if not interactive:
+        if not interactive and config.daemon.sync_enabled:
             last_check_ts, warned_ts = ops.get_drift_state(repo_path)
             current_time = time.time()
 
@@ -441,18 +441,19 @@ def run_backup(original_path_str: str, interactive: bool = False) -> None:
                         console.print(f"[green]Committed {repo_path.name}[/green]")
 
         # --- PUSH PHASE ---
-        current_local_ts = _get_ref_timestamp(repo, local_backup_ref)
-        last_push_ts = _get_ref_timestamp(repo, remote_backup_ref)
+        if config.daemon.sync_enabled:
+            current_local_ts = _get_ref_timestamp(repo, local_backup_ref)
+            last_push_ts = _get_ref_timestamp(repo, remote_backup_ref)
 
-        time_since_push = time.time() - last_push_ts
-        has_new_data = current_local_ts > last_push_ts
+            time_since_push = time.time() - last_push_ts
+            has_new_data = current_local_ts > last_push_ts
 
-        if has_new_data and (
-            time_since_push >= config.daemon.push_interval or interactive
-        ):
-            refspec = f"{local_backup_ref}:{local_backup_ref}"
-            # Pass config to _attempt_push
-            _attempt_push(repo, refspec, config, interactive)
+            if has_new_data and (
+                time_since_push >= config.daemon.push_interval or interactive
+            ):
+                refspec = f"{local_backup_ref}:{local_backup_ref}"
+                # Pass config to _attempt_push
+                _attempt_push(repo, refspec, config, interactive)
 
     except Exception:
         logger.exception(f"CRITICAL {repo_path.name}: Backup iteration failed")

--- a/src/git_pulsar/ops.py
+++ b/src/git_pulsar/ops.py
@@ -234,6 +234,13 @@ def sync_session() -> None:
     the most recent one, and (after confirmation) resets the local working directory
     to match it. This facilitates "Smart Handoff" between devices.
     """
+    config = Config.load(Path.cwd())
+    if not config.daemon.sync_enabled:
+        console.print(
+            "[bold red]ERROR:[/bold red] Sync is disabled. Enable `sync_enabled = true` in your configuration."
+        )
+        sys.exit(1)
+
     repo = GitRepo(Path.cwd())
     current_branch = repo.current_branch()
 
@@ -351,23 +358,25 @@ def finalize_work() -> None:
 
     try:
         # 2. Sync with Remote.
-        with console.status(
-            "[bold blue]Syncing with origin...[/bold blue]", spinner="dots"
-        ):
-            try:
-                repo._run(["fetch", "origin", "main"], capture=True)
-                repo._run(
-                    [
-                        "fetch",
-                        "origin",
-                        f"refs/heads/{BACKUP_NAMESPACE}/*:refs/heads/{BACKUP_NAMESPACE}/*",
-                    ],
-                    capture=True,
-                )
-            except Exception as e:
-                console.print(
-                    f"[yellow][bold]WARNING:[/bold] Fetch warning: {e}[/yellow]"
-                )
+        config = Config.load(Path.cwd())
+        if config.daemon.sync_enabled:
+            with console.status(
+                "[bold blue]Syncing with origin...[/bold blue]", spinner="dots"
+            ):
+                try:
+                    repo._run(["fetch", "origin", "main"], capture=True)
+                    repo._run(
+                        [
+                            "fetch",
+                            "origin",
+                            f"refs/heads/{BACKUP_NAMESPACE}/*:refs/heads/{BACKUP_NAMESPACE}/*",
+                        ],
+                        capture=True,
+                    )
+                except Exception as e:
+                    console.print(
+                        f"[yellow][bold]WARNING:[/bold] Fetch warning: {e}[/yellow]"
+                    )
 
         # 3. Identify Backup Candidates for the current branch.
         candidates = repo.list_refs(f"refs/heads/{BACKUP_NAMESPACE}/*/{working_branch}")

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -16,6 +16,7 @@ def mock_config(mocker: MagicMock) -> Config:
     conf = Config()
     conf.daemon.commit_interval = 0
     conf.daemon.push_interval = 0
+    conf.daemon.sync_enabled = True
     mocker.patch("git_pulsar.daemon.Config.load", return_value=conf)
     return conf
 

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -118,6 +118,7 @@ def test_sync_session_success(mocker: MagicMock) -> None:
     Args:
         mocker (MagicMock): Pytest fixture for mocking.
     """
+    mocker.patch("git_pulsar.ops.Config.load").return_value.daemon.sync_enabled = True
     mocker.patch("git_pulsar.ops.GitRepo")
     repo = mocker.patch("git_pulsar.ops.GitRepo").return_value
     repo.current_branch.return_value = "main"


### PR DESCRIPTION
## Description

This PR transitions Git Pulsar from having multi-machine synchronization enabled by default, to being a local-first autosave tool where distributed features are explicitly opt-in. This dramatically reduces the complexity and surface area for users who only want to protect a single local machine without hitting the network.

## Changes

- **Config**: Added `sync_enabled` boolean to `DaemonConfig` (default: `False`).
- **Daemon Loop**: Gated drift detection (roaming radar) and remote push operations in `daemon.py` behind `sync_enabled`. 
- **CLI Commands**:
  - `sync`: Exits gracefully with a helpful message if sync is disabled.
  - `finalize`: Skips network fetches (`fetch origin main`, etc.) when sync is disabled, but continues to perform a local octopus squash of available shadow backups, keeping the command useful for local-only users.
- **Documentation**: Reframed the README to emphasize local autosave capabilities first, clearly marking features that require `sync_enabled = true`.
- **Testing**: Updated `test_distributed.sh` and `test_daemon.py` fixtures to explicitly enable `sync_enabled = True` to preserve full test coverage of distributed features.

Fixes user concerns regarding the default complexity of the multi-machine topology.