### PR TITLE
fix(daemon): isolate shadow index, deepcopy config cache, and cancel signal alarm

### DIFF
--- a/src/git_pulsar/config.py
+++ b/src/git_pulsar/config.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 import re
 import tomllib
@@ -157,8 +158,8 @@ class Config:
                 instance._merge_from_file(CONFIG_FILE)
             cls._global_cache = instance
 
-        # Start with a copy of the cached global config
-        instance = replace(cls._global_cache)
+        # Start with a deep copy of the cached global config
+        instance = copy.deepcopy(cls._global_cache)
 
         # 2. Load Local Config (if applicable)
         if repo_path:

--- a/src/git_pulsar/daemon.py
+++ b/src/git_pulsar/daemon.py
@@ -400,10 +400,6 @@ def run_backup(original_path_str: str, interactive: bool = False) -> None:
         if time_since_commit >= config.daemon.commit_interval:
             with temporary_index(repo_path) as env:
                 # Stage current working directory into temp index.
-                # Use wrapper method if available, or repo._run(["add", "."], env=env)
-                repo.add_all()
-                # Note: GitRepo.add_all() in wrapper doesn't accept env.
-                # Keeping manual run with env.
                 repo._run(["add", "."], env=env)
 
                 # Write Tree.
@@ -526,8 +522,10 @@ def main(interactive: bool = False) -> None:
         try:
             # 5 second timeout per repo to prevent hanging.
             signal.alarm(5)
-            run_backup(repo_str, interactive=interactive)
-            signal.alarm(0)  # Disable alarm.
+            try:
+                run_backup(repo_str, interactive=interactive)
+            finally:
+                signal.alarm(0)  # Disable alarm.
         except TimeoutError:
             logger.warning(f"TIMEOUT {repo_str}: Skipped (possible stalled mount).")
         except Exception:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -153,3 +153,29 @@ def test_config_invalid_keys_and_values(
         "Config error in [daemon].commit_interval: Invalid time format" in caplog.text
     )
     assert "Config error in [limits].max_log_size: Invalid size format" in caplog.text
+
+
+def test_config_load_does_not_mutate_global_cache(
+    tmp_path: Path, mocker: MagicMock
+) -> None:
+    """Verifies that loading repo-specific overrides does not mutate the in-memory global cache."""
+    global_config_path = tmp_path / "global_config.toml"
+    global_config_path.write_text('[files]\nignore = ["*.global"]\n')
+    mocker.patch("git_pulsar.config.CONFIG_FILE", global_config_path)
+
+    # 1. Load global config
+    global_conf = Config.load()
+    assert global_conf.files.ignore == ["*.global"]
+
+    # 2. Load repo config with additional ignores
+    repo_path = tmp_path / "repo1"
+    repo_path.mkdir()
+    local_toml = repo_path / "pulsar.toml"
+    local_toml.write_text('[files]\nignore = ["*.local"]\n')
+    repo_conf = Config.load(repo_path=repo_path)
+    assert "*.global" in repo_conf.files.ignore
+    assert "*.local" in repo_conf.files.ignore
+
+    # 3. Verify global cache was not mutated
+    fresh_global = Config.load()
+    assert fresh_global.files.ignore == ["*.global"]

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -57,6 +57,7 @@ def test_run_backup_shadow_commit_flow(
     daemon.run_backup(str(tmp_path))
 
     # Assert plumbing usage
+    repo.add_all.assert_not_called()
     repo._run.assert_any_call(["add", "."], env=mocker.ANY)
     repo.write_tree.assert_called_once()
     repo.commit_tree.assert_called_once()
@@ -183,3 +184,26 @@ def test_run_backup_drift_detection_triggers_notification(
 
     # Assert state was updated so we don't spam the user again for timestamp 5000
     mock_set_state.assert_called_once_with(tmp_path.resolve(), current_time, 5000)
+
+
+def test_main_signal_alarm_reset_on_exception(
+    tmp_path: Path, mocker: MagicMock
+) -> None:
+    """Verifies that signal.alarm(0) is executed even when run_backup raises an error."""
+    mock_repo = tmp_path / "repo1"
+    mocker.patch("git_pulsar.system.get_registered_repos", return_value=[mock_repo])
+    mocker.patch(
+        "git_pulsar.daemon.run_backup", side_effect=RuntimeError("Simulated failure")
+    )
+    mocker.patch("git_pulsar.daemon.run_maintenance")
+    mocker.patch("git_pulsar.daemon.setup_logging")
+
+    mock_alarm = mocker.patch("signal.alarm")
+
+    daemon.main(interactive=False)
+
+    # Verify signal.alarm(5) was set and signal.alarm(0) was cleared
+    assert mock_alarm.call_args_list == [
+        mocker.call(5),
+        mocker.call(0),
+    ]


### PR DESCRIPTION
## Summary

This PR addresses three critical stability and data isolation issues (P0) identified during the codebase audit:

1. **Shadow Index Staging Leak**: Removed the accidental `repo.add_all()` call in `daemon.py`. Previously, this called `git add .` without specifying `env=env`, which staged modified and untracked files into the user's primary Git index (`.git/index`) during background shadow backup runs. Backups now strictly stage into the isolated `pulsar_index` via `repo._run(["add", "."], env=env)`.
2. **Global Config Cache Mutation**: Updated `Config.load()` to use `copy.deepcopy(cls._global_cache)` instead of `dataclasses.replace()`. This prevents local repository overrides (e.g. `files.ignore`) from mutating the shared in-memory global config singleton across repository loads.
3. **Signal Alarm Leak / Ghost Timeouts**: Wrapped repository processing in `daemon.main()` with a `try ... finally` block ensuring `signal.alarm(0)` is unconditionally executed. This prevents pending 5-second alarms from leaking across loop iterations or firing during maintenance if a repository backup raises an unhandled exception.

## Changes

- `src/git_pulsar/daemon.py`:
  - Removed `repo.add_all()` call inside `run_backup()`.
  - Added `finally: signal.alarm(0)` around per-repository backup execution in `main()`.
- `src/git_pulsar/config.py`:
  - Imported `copy` and replaced `replace(cls._global_cache)` with `copy.deepcopy(cls._global_cache)` in `Config.load()`.
- `tests/test_daemon.py`:
  - Asserted that `repo.add_all()` is not invoked in `test_run_backup_shadow_commit_flow`.
  - Added `test_main_signal_alarm_reset_on_exception` to verify alarm cancellation on errors.
- `tests/test_config.py`:
  - Added `test_config_load_does_not_mutate_global_cache` to verify cache immutability across local loads.

## Verification
- Unit tests & coverage: `uv run pytest --cov` passed (64.8% coverage).
- Distributed sandbox: `bash scripts/test_distributed.sh` passed.
- Linting & type checking: `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy .` passed cleanly.