### PR TITLE
fix(cli): polish doctor diagnostics, add registry file locking, and exact match gitignore

### DIFF
--- a/src/git_pulsar/cli.py
+++ b/src/git_pulsar/cli.py
@@ -1,5 +1,6 @@
 import argparse
 import datetime
+import fcntl
 import logging
 import os
 import subprocess
@@ -464,18 +465,34 @@ def unregister_repo() -> None:
         console.print("Registry is empty.", style="yellow")
         return
 
-    current_paths = [str(p) for p in system.get_registered_repos()]
-    if cwd not in current_paths:
-        console.print(
-            f"Current path not registered: [cyan]{cwd}[/cyan]", style="yellow"
-        )
-        return
+    tmp_file = REGISTRY_FILE.with_suffix(".tmp")
+    try:
+        with open(REGISTRY_FILE, "r+") as f:
+            fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+            try:
+                current_paths = [line.strip() for line in f if line.strip()]
+                if cwd not in current_paths:
+                    console.print(
+                        f"Current path not registered: [cyan]{cwd}[/cyan]",
+                        style="yellow",
+                    )
+                    return
 
-    with open(REGISTRY_FILE, "w") as f:
-        for path in current_paths:
-            if path != cwd:
-                f.write(f"{path}\n")
-    console.print(f"✔ Unregistered: [cyan]{cwd}[/cyan]", style="green")
+                with open(tmp_file, "w") as tf:
+                    for path in current_paths:
+                        if path != cwd:
+                            tf.write(f"{path}\n")
+                    tf.flush()
+                    os.fsync(tf.fileno())
+
+                os.replace(tmp_file, REGISTRY_FILE)
+            finally:
+                fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+        console.print(f"✔ Unregistered: [cyan]{cwd}[/cyan]", style="green")
+    except OSError as e:
+        logger.error(f"Failed to unregister repository: {e}")
+        if tmp_file.exists():
+            tmp_file.unlink()
 
 
 def _check_systemd_linger() -> str | None:
@@ -841,33 +858,6 @@ def run_doctor() -> None:
             else:
                 console.print("   [dim]Skipped.[/dim]")
 
-    # 2. Check logs for recent errors using dynamic window (Event Check).
-    conf = Config.load()
-    lookback_secs = conf.daemon.push_interval * 3
-    recent_errors = _analyze_logs(seconds=lookback_secs)
-
-    # 3. Correlate State and Events
-    if recent_errors:
-        lookback_hours = lookback_secs // 3600
-        time_str = f"{lookback_hours}h" if lookback_hours > 0 else f"{lookback_secs}s"
-
-        if is_healthy:
-            console.print(
-                f"   [dim]i {len(recent_errors)} transient error(s) logged in the last "
-                f"{time_str}, but system automatically recovered.[/dim]"
-            )
-        else:
-            console.print(
-                f"   [red]✘ Found {len(recent_errors)} active error(s) in the last "
-                f"{time_str}:[/red]"
-            )
-            for err in recent_errors[-3:]:  # Show last 3
-                console.print(f"     [dim]{err}[/dim]")
-            if len(recent_errors) > 3:
-                console.print("     ... (run 'git pulsar log' to see full history)")
-    else:
-        console.print("   [green]✔ Recent logs are clean.[/green]")
-
 
 def add_ignore_cli(pattern: str) -> None:
     """Adds a file pattern to the repository's ignore list.
@@ -958,9 +948,11 @@ def setup_repo(registry_path: Path = REGISTRY_FILE) -> None:
                 style="dim",
             )
             with open(gitignore) as f:
-                existing_content = f.read()
+                existing_lines = {line.strip() for line in f}
 
-            missing_defaults = [d for d in DEFAULT_IGNORES if d not in existing_content]
+            missing_defaults = [
+                d for d in DEFAULT_IGNORES if d.strip() not in existing_lines
+            ]
 
             if missing_defaults:
                 console.print(
@@ -982,12 +974,19 @@ def setup_repo(registry_path: Path = REGISTRY_FILE) -> None:
         registry_path.touch()
 
     with open(registry_path, "r+") as f:
-        content = f.read()
-        if str(cwd) not in content:
-            f.write(f"{cwd}\n")
-            console.print(f"Registered: [cyan]{cwd}[/cyan]", style="green")
-        else:
-            console.print("Already registered.", style="dim")
+        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+        try:
+            content = f.read()
+            if str(cwd) not in [line.strip() for line in content.splitlines()]:
+                f.seek(0, os.SEEK_END)
+                f.write(f"{cwd}\n")
+                f.flush()
+                os.fsync(f.fileno())
+                console.print(f"Registered: [cyan]{cwd}[/cyan]", style="green")
+            else:
+                console.print("Already registered.", style="dim")
+        finally:
+            fcntl.flock(f.fileno(), fcntl.LOCK_UN)
 
     console.print("\n[bold green]✔ Pulsar Active.[/bold green]")
 

--- a/src/git_pulsar/daemon.py
+++ b/src/git_pulsar/daemon.py
@@ -1,5 +1,6 @@
 import atexit
 import datetime
+import fcntl
 import logging
 import os
 import signal
@@ -216,21 +217,24 @@ def prune_registry(original_path_str: str) -> None:
     tmp_file = REGISTRY_FILE.with_suffix(".tmp")
 
     try:
-        # 1. Read existing registry.
-        with open(REGISTRY_FILE) as f:
-            lines = f.readlines()
+        # 1. Read existing registry and rewrite atomically while holding exclusive lock.
+        with open(REGISTRY_FILE, "r+") as f:
+            fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+            try:
+                lines = f.readlines()
+                # 2. Write valid lines to temp file.
+                with open(tmp_file, "w") as tf:
+                    for line in lines:
+                        clean_line = line.strip()
+                        if clean_line and clean_line != target:
+                            tf.write(clean_line + "\n")
+                    tf.flush()
+                    os.fsync(tf.fileno())  # Force write to disk.
 
-        # 2. Write valid lines to temp file.
-        with open(tmp_file, "w") as f:
-            for line in lines:
-                clean_line = line.strip()
-                if clean_line and clean_line != target:
-                    f.write(clean_line + "\n")
-            f.flush()
-            os.fsync(f.fileno())  # Force write to disk.
-
-        # 3. Atomic Swap.
-        os.replace(tmp_file, REGISTRY_FILE)
+                # 3. Atomic Swap.
+                os.replace(tmp_file, REGISTRY_FILE)
+            finally:
+                fcntl.flock(f.fileno(), fcntl.LOCK_UN)
 
         repo_name = Path(original_path_str).name
         logger.info(f"PRUNED: {original_path_str} removed from registry.")

--- a/src/git_pulsar/ops.py
+++ b/src/git_pulsar/ops.py
@@ -529,7 +529,8 @@ def add_ignore(pattern: str) -> None:
             with open(gitignore) as f:
                 content = f.read()
 
-        if pattern in content:
+        existing_lines = {line.strip() for line in content.splitlines()}
+        if pattern.strip() in existing_lines:
             console.print(f"[blue]INFO:[/blue] '{pattern}' is already in .gitignore.")
         else:
             with open(gitignore, "a") as f:

--- a/src/git_pulsar/system.py
+++ b/src/git_pulsar/system.py
@@ -1,3 +1,4 @@
+import fcntl
 import logging
 import os
 import plistlib
@@ -25,8 +26,16 @@ def get_registered_repos() -> list[Path]:
     """Reads the registry file and returns a list of registered repository paths."""
     if not REGISTRY_FILE.exists():
         return []
-    with open(REGISTRY_FILE) as f:
-        return [Path(line.strip()) for line in f if line.strip()]
+    try:
+        with open(REGISTRY_FILE) as f:
+            fcntl.flock(f.fileno(), fcntl.LOCK_SH)
+            try:
+                return [Path(line.strip()) for line in f if line.strip()]
+            finally:
+                fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+    except Exception as e:
+        logger.debug(f"Failed to read registry: {e}")
+        return []
 
 
 class SystemStrategy:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -261,6 +261,39 @@ def test_setup_repo_triggers_identity_config(tmp_path: Path, mocker: MagicMock) 
     assert isinstance(args[0], GitRepo)
 
 
+def test_setup_repo_exact_gitignore_matching(tmp_path: Path, mocker: MagicMock) -> None:
+    """Verifies that setup_repo checks .gitignore lines exactly rather than substrings."""
+    (tmp_path / ".git").mkdir()
+    gitignore = tmp_path / ".gitignore"
+    # Write a pattern that contains '*.log' as a substring
+    gitignore.write_text("my_special_*.log\n")
+
+    mocker.patch.object(Path, "cwd", return_value=tmp_path)
+    mock_registry = tmp_path / "registry"
+    mocker.patch("git_pulsar.system.configure_identity")
+
+    cli.setup_repo(registry_path=mock_registry)
+
+    content = gitignore.read_text()
+    assert "*.log" in content.splitlines()
+
+
+def test_unregister_repo_removes_entry(tmp_path: Path, mocker: MagicMock) -> None:
+    """Verifies that unregister_repo removes the current directory from the registry file."""
+    mocker.patch.object(Path, "cwd", return_value=tmp_path)
+    mock_registry = tmp_path / "registry"
+    mock_registry.write_text(f"{tmp_path}\n/other/path\n")
+    mocker.patch("git_pulsar.cli.REGISTRY_FILE", mock_registry)
+
+    cli.unregister_repo()
+
+    lines = [
+        line.strip() for line in mock_registry.read_text().splitlines() if line.strip()
+    ]
+    assert str(tmp_path) not in lines
+    assert "/other/path" in lines
+
+
 def test_check_systemd_linger_non_linux(mocker: MagicMock) -> None:
     """Verifies that the linger check safely ignores non-Linux platforms.
 

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -409,3 +409,19 @@ def test_has_large_files_uses_config_limit(tmp_path: Path, mocker: MagicMock) ->
     assert result is True
     # Verify the mock strategy intercepted the call
     mock_strat.notify.assert_called_with("Backup Aborted", mocker.ANY)
+
+
+def test_ignore_pattern_exact_line_match(tmp_path: Path, mocker: MagicMock) -> None:
+    """Verifies that ops.add_ignore checks exact lines instead of substring containment."""
+    mocker.patch.object(Path, "cwd", return_value=tmp_path)
+    gitignore = tmp_path / ".gitignore"
+    gitignore.write_text("sub_foo.txt\n")
+
+    mocker.patch("git_pulsar.ops.console")
+    mock_git = mocker.patch("git_pulsar.ops.GitRepo")
+    mock_git.return_value.status_porcelain.return_value = []
+
+    ops.add_ignore("foo.txt")
+
+    content = gitignore.read_text()
+    assert "foo.txt" in content.splitlines()


### PR DESCRIPTION
## Summary

This PR completes the codebase audit polish items (P2):

1. **Removed Duplicate Doctor Diagnostics**: Cleaned up the redundant second log check block in `run_doctor` in `src/git_pulsar/cli.py`.
2. **Registry Concurrency & File Locking**: Wrapped `REGISTRY_FILE` reading and atomic updating with `fcntl.flock` (`LOCK_SH` for reads in `system.get_registered_repos`, `LOCK_EX` for writes in `cli.setup_repo`, `cli.unregister_repo`, and `daemon.prune_registry`) to prevent race conditions during concurrent daemon and CLI operations.
3. **Exact Line Matching for .gitignore Rules**: Updated pattern checks in `cli.setup_repo` and `ops.add_ignore` from substring containment (`pattern in content`) to exact stripped line comparison (`pattern.strip() in {line.strip() for line in lines}`), preventing false positives when pattern names are substrings of existing ignore rules or comments.

## Changes
- `src/git_pulsar/cli.py`: Removed duplicate `_analyze_logs` block in `run_doctor`; added `fcntl.flock` to `setup_repo` and `unregister_repo`; added exact line matching for default ignores.
- `src/git_pulsar/daemon.py`: Added `fcntl.flock` during atomic `prune_registry`.
- `src/git_pulsar/system.py`: Added shared `fcntl.flock` in `get_registered_repos`.
- `src/git_pulsar/ops.py`: Switched `add_ignore` to exact line matching.
- `tests/test_cli.py`: Added tests for exact `.gitignore` defaults matching and `unregister_repo`.
- `tests/test_ops.py`: Added test for exact line matching in `ops.add_ignore`.

## Verification
- `uv run pytest --cov` passed (102 tests, 67.8% coverage).
- `bash scripts/test_distributed.sh` passed.
- `uv run ruff check .`, `uv run ruff format --check .`, and `uv run mypy .` passed cleanly.